### PR TITLE
Add --no-results option

### DIFF
--- a/literategit/__init__.py
+++ b/literategit/__init__.py
@@ -24,7 +24,7 @@ import jinja2
 
 
 class TemplateSuite:
-    def __init__(self, create_url, title):
+    def __init__(self, create_url, title, has_results=True):
         """
         Create a TemplateSuite instance from the given 'URL factory' and title.
 
@@ -51,6 +51,7 @@ class TemplateSuite:
         env.filters['suppress_no_lineno'] = Diff.suppress_no_lineno
         env.filters['markdown'] = self.markdown
         env.filters['section_path'] = lambda path: '.'.join(map(str, path))
+        env.globals['has_results'] = has_results
         env.globals['project_title'] = title
         self.node = env.get_template('node.html.tmpl')
         self.content = env.get_template('content.html.tmpl')
@@ -176,7 +177,7 @@ def list_from_range(repo, base_branch_name, branch_name):
     return elements
 
 
-def render(nodes, create_url, title):
-    templates = TemplateSuite(create_url, title)
+def render(nodes, create_url, title, has_results=True):
+    templates = TemplateSuite(create_url, title, has_results)
     content = templates.content.render(nodes=nodes)
     return templates.page.render(content=content)

--- a/literategit/cli/render.py
+++ b/literategit/cli/render.py
@@ -20,11 +20,12 @@
 Usage:
   git-literate-render (-h | --help)
   git-literate-render --version
-  git-literate-render <title> <begin-commit> <end-commit> <create-url>
+  git-literate-render <title> <begin-commit> <end-commit> <create-url> [--no-results]
 
 Options:
-  -h --help    Show this help info
-  --version    Display version info and exit
+  -h --help     Show this help info
+  --version     Display version info and exit
+  --no\-results Don't add a results link to each commit
 
 Write, to stdout, an HTML representation of the repo history starting
 from (but excluding) <begin-commit> and ending, inclusively, with
@@ -71,4 +72,4 @@ def render(_argv=None, _path=None, _print=print):
 
     create_url = getattr(create_url_module, obj_name)
 
-    _print(literategit.render(sections, create_url, args['<title>']))
+    _print(literategit.render(sections, create_url, args['<title>'], not args['--no-results']))

--- a/literategit/node.html.tmpl
+++ b/literategit/node.html.tmpl
@@ -9,8 +9,10 @@
 <div class="message-body">{{ node.message_body | markdown }}</div>
 
 <p class="links">
+{% if has_results %}
   <a target="LiterateGitResult"
      href="{{ node.commit.oid | result_url }}"><span>RESULT</span></a>
+{% endif %}
   <a target="LiterateGitSource"
      href="{{ node.commit.oid | source_url }}"><span>SOURCE</span></a>
 </p>


### PR DESCRIPTION
In my use case, I don't have web app to bring the user to at each step, so I added a CLI option to prevent the results link from being rendered. Hopefully someone else might find this useful!