### PR TITLE
Fix expand button being cut off on mobile

### DIFF
--- a/literategit/literate-git.css
+++ b/literategit/literate-git.css
@@ -20,9 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 .markdown-body {
     box-sizing: border-box;
     min-width: 200px;
-    max-width: 980px;
+    max-width: 1160px;
     margin: 0 auto;
-    padding: 45px;
+    /* Use more padding on left and right to prevent expand buttons
+     * being cut off on smaller viewports
+     */
+    padding: 45px 90px 45px 90px;
     line-height: 1.4444;
 }
 


### PR DESCRIPTION
If you resize the window width down, sometimes the expand button gets cut off, especially on mobile. This converts some of the width into padding to prevent that